### PR TITLE
detect correct dependency order for models

### DIFF
--- a/plugin/generate.sh
+++ b/plugin/generate.sh
@@ -8,3 +8,12 @@ CLASSPATH=${PLUGINDIR}/target/julia-swagger-codegen-0.0.1.jar:${SWAGGERDIR}/modu
 #SWAGGERDEBUG="-DdebugModels -DdebugSwagger -DdebugOperations -DdebugSupportingFiles"
 
 java ${SWAGGERDEBUG} -cp ${CLASSPATH} io.swagger.codegen.SwaggerCodegen generate -l julia $*
+
+while getopts "i:c:o:" arg; do
+    case $arg in
+    o)
+        echo "resolving model order in ${OPTARG}"
+        julia -e "include(joinpath("\""$DIR"\"", "\""resolve.jl"\"")); genincludes("\""$OPTARG"\"")"
+        ;;
+    esac
+done

--- a/plugin/resolve.jl
+++ b/plugin/resolve.jl
@@ -1,0 +1,110 @@
+# Types in Julia need to be loaded in correct order for dependencies to be resolved.
+# This utility script determines the correct order for including generated models.
+#
+# It parses each model and keeps a table of the other models it refers to.
+# At the end it walks through the dependency tree and outputs include statements in the correct order.
+
+function typedeps(file::String)
+    modulename = split(basename(file), ".")[1]
+    contents = readstring(file)
+    wrapped = """module $modulename
+        $contents
+    end"""
+    typedeps(parse(wrapped))
+end
+
+function findtype(X::Expr, what::Symbol)
+    (X.head === what) && (return X)
+    for x in X.args
+        isa(x, Expr) && (x.head === what) && return x
+    end
+    error("no $what in expression")
+end
+
+function isbasetype(DT)
+    try
+        T = eval(DT)
+        issubtype(T, Number) || issubtype(T, String)
+    catch
+        false
+    end
+end
+
+function pushdeps(deps, DT)
+    if isa(DT, Expr) && DT.args[1] === :Vector
+        pushdeps(deps, DT.args[2])
+    elseif isa(DT, Expr) && DT.args[1] === :Dict
+        pushdeps(deps, DT.args[2])
+        pushdeps(deps, DT.args[3])
+    elseif !isbasetype(DT)
+        info("    depends on ", DT)
+        push!(deps, DT)
+    end
+end
+
+function typedeps(M::Expr)
+    mod = findtype(M, :module)
+    modblock = findtype(mod, :block)
+    typ = findtype(modblock, :type)
+    typedecl = findtype(typ, :<:)
+    typeblock = findtype(typ, :block)
+
+    typename = typedecl.args[1]
+    @assert typedecl.args[2] === :SwaggerModel
+
+    deps = Vector{Symbol}()
+    for d in typeblock.args
+        if d.head === :(::)
+            nullable_type = d.args[2]
+            if nullable_type.head === :curly && nullable_type.args[1] === :Nullable
+                pushdeps(deps, nullable_type.args[2])
+            end
+        end
+    end
+    (typename, deps)
+end
+
+srcdir(folder) = joinpath(folder, "src")
+fullsrcpath(folder, file) = joinpath(srcdir(folder), file)
+
+function gentypetree(folder::String)
+    info("reading $folder/src/model_*.jl")
+    TT = Dict{Symbol, Vector{Symbol}}()
+    TF = Dict{Symbol,String}()
+    for file in readdir(srcdir(folder))
+        if startswith(file, "model_")
+            info("parsing ", file)
+            typename, deps = typedeps(fullsrcpath(folder, file))
+            TT[typename] = deps
+            TF[typename] = file
+        end
+    end
+    TT, TF
+end
+
+satisfied(typename, TT, generated) = (isempty(TT[typename]) || (typename in generated))
+
+function gen(typename, TT, TF, generated, io=STDOUT)
+    (typename in generated) && return
+    if !satisfied(typename, TT, generated)
+        for T in TT[typename]
+            gen(T, TT, TF, generated, io)
+        end
+    end
+    println(io, "include(\"", TF[typename], "\")")
+    push!(generated, typename)
+    nothing
+end
+
+function genincludes(folder::String)
+    generated = Set{Symbol}()
+    TT, TF = gentypetree(folder)
+
+    open(fullsrcpath(folder, "modelincludes.jl"), "w") do inclfile
+        for typename in keys(TT)
+            gen(typename, TT, TF, generated, inclfile)
+        end
+    end
+
+    nothing
+end

--- a/plugin/src/main/java/com/juliacomputing/swagger/codegen/JuliaGenerator.java
+++ b/plugin/src/main/java/com/juliacomputing/swagger/codegen/JuliaGenerator.java
@@ -10,10 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class JuliaGenerator extends DefaultCodegen implements CodegenConfig {
 
-    public static final String MODEL_ORDER = "modelOrder";
-
     protected String packageName;
-    protected String[] modelOrder;
 
     // source folder where to write the files
     protected String sourceFolder = "src";
@@ -119,15 +116,10 @@ public class JuliaGenerator extends DefaultCodegen implements CodegenConfig {
 
         cliOptions.clear();
         cliOptions.add(new CliOption(CodegenConstants.PACKAGE_NAME, "Julia package name.").defaultValue("SwaggerClient"));
-        cliOptions.add(new CliOption(MODEL_ORDER, "Model names ordered by dependency.").defaultValue(""));
     }
 
     public void setPackageName(String packageName) {
         this.packageName = packageName;
-    }
-
-    public void setModelOrder(String[] modelOrder) {
-        this.modelOrder = modelOrder;
     }
 
     @Override
@@ -139,14 +131,6 @@ public class JuliaGenerator extends DefaultCodegen implements CodegenConfig {
         }
         else {
             setPackageName("SwaggerClient");
-        }
-
-        if (additionalProperties.containsKey(MODEL_ORDER)) {
-            String modelOrderVal = (String)additionalProperties.get(MODEL_ORDER);
-            modelOrderVal = modelOrderVal.replace("[", "");
-            modelOrderVal = modelOrderVal.replace("]", "");
-            setModelOrder(StringUtils.split(modelOrderVal, " ,"));
-            additionalProperties.put(MODEL_ORDER, modelOrder);
         }
 
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);

--- a/plugin/src/main/resources/julia/client.mustache
+++ b/plugin/src/main/resources/julia/client.mustache
@@ -9,13 +9,8 @@ using Swagger
 import Swagger: set_field!, get_field, isset_field, validate_field, SwaggerApi, SwaggerModel
 import Base: convert
 
-{{#modelOrder}}
-include("model_{{.}}.jl")
-{{/modelOrder}}{{^modelOrder}}
-{{#models}}
-{{#model}}
-include("{{classFilename}}.jl")
-{{/model}}{{/models}}{{/modelOrder}}{{#apiInfo}}{{#apis}}
+include("modelincludes.jl")
+{{#apiInfo}}{{#apis}}
 include("api_{{classname}}.jl"){{/apis}}{{/apiInfo}}
 
 # export models


### PR DESCRIPTION
Types in Julia need to be loaded in correct order for dependencies to be resolved.

Prior to this change the code generator depended on a manual input (via. configuration file) to include models.

This adds a code generation step that:
- parses each generated model and keeps a table of the other models it refers to
- walks through the dependency tree and outputs include statements in the correct order

ref: https://github.com/JuliaComputing/Kuber.jl/issues/3