### PR TITLE
fix ssl verification flag for HTTP.jl

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -65,9 +65,9 @@ struct Client
     get_return_type::Function   # user provided hook to get return type from response data
     clntoptions::Dict
 
-    function Client(root::String; headers::Dict{String,String}=Dict{String,String}(), get_return_type::Function=(default,data)->default, tlsconfig=nothing)
+    function Client(root::String; headers::Dict{String,String}=Dict{String,String}(), get_return_type::Function=(default,data)->default, tlsconfig=nothing, require_ssl_verification=true)
         endswith(root, '/') && warn("Root URI ($root) terminates with '/'. Ensure that resource paths do not begin with '/'. This is unconventional.")
-        clntoptions = Dict(:tlsconfig=>tlsconfig, :status_exception=>false, :retries=>0)
+        clntoptions = Dict(:tlsconfig=>tlsconfig, :status_exception=>false, :retries=>0, :require_ssl_verification=>require_ssl_verification)
         new(root, headers, get_return_type, clntoptions)
     end
 end


### PR DESCRIPTION
HTTP.jl needs the flag to be provided sepatately (not as part of tlsconfig)