### PR TITLE
fixes client ssl args

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -65,9 +65,9 @@ struct Client
     get_return_type::Function   # user provided hook to get return type from response data
     clntoptions::Dict
 
-    function Client(root::String; headers::Dict{String,String}=Dict{String,String}(), get_return_type::Function=(default,data)->default, tlsconfig=nothing, require_ssl_verification=true)
+    function Client(root::String; headers::Dict{String,String}=Dict{String,String}(), get_return_type::Function=(default,data)->default, sslconfig=nothing, require_ssl_verification=true)
         endswith(root, '/') && warn("Root URI ($root) terminates with '/'. Ensure that resource paths do not begin with '/'. This is unconventional.")
-        clntoptions = Dict(:tlsconfig=>tlsconfig, :status_exception=>false, :retries=>0, :require_ssl_verification=>require_ssl_verification)
+        clntoptions = Dict(:sslconfig=>sslconfig, :status_exception=>false, :retries=>0, :require_ssl_verification=>require_ssl_verification)
         new(root, headers, get_return_type, clntoptions)
     end
 end


### PR DESCRIPTION
Fixes SSL arguments for swagger client, currently it passes `tlsconfig` the but the `HTTP.request` functions expects `sslconfig` keyword argument https://github.com/JuliaWeb/HTTP.jl/blob/086157b9ba343b3df5c0abe46ff726c67ca2fafa/src/HTTP.jl#L132