### PR TITLE
detect fields declared as const

### DIFF
--- a/plugin/src/main/java/com/juliacomputing/swagger/codegen/JuliaGenerator.java
+++ b/plugin/src/main/java/com/juliacomputing/swagger/codegen/JuliaGenerator.java
@@ -327,9 +327,16 @@ public class JuliaGenerator extends DefaultCodegen implements CodegenConfig {
             if(languageSpecificPrimitives.contains(type))
                 return toModelName(type);
         }
-        else
+        else {
             type = swaggerType;
-        return toModelName(type);
+        }
+
+        if (type == null) {
+            return "Object";
+        }
+        else {
+            return toModelName(type);
+        }
     }
 
     /**


### PR DESCRIPTION
A constant parameter is not the same as the default parameter value. A constant parameter is always sent by the client, whereas the default value is something that the server uses if the parameter is not sent by the client.

E.g.:
```
    "resourceType": {
      "const": "Goal",
      "description": "This is a Goal resource"
    },
```

Constant parameters are presented as `UntypedProperty` types. They are generated in Julia code as `Any`. The `UntypedProperty` object does not seem to hold the value of the constant. So that must be set by the client code.