### PR TITLE
use local petstore to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: julia
 os:
   - linux
+services:
+  - docker
 jdk:
   - openjdk11
   - oraclejdk11
@@ -10,6 +12,8 @@ cache:
     - "$HOME/.m2/repository"
     - "$HOME/apache-maven-3.5.0"
 before_install:
+  - docker pull swaggerapi/petstore:latest
+  - docker run -d -e SWAGGER_HOST=http://127.0.0.1 -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore:latest
   - export M2_HOME=$HOME/apache-maven-3.5.0
   - if [ ! -d $M2_HOME/bin ]; then curl https://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz | tar zxf - -C $HOME; fi
   - export PATH=$M2_HOME/bin:$PATH

--- a/test/petstore/generate.sh
+++ b/test/petstore/generate.sh
@@ -3,4 +3,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PKGDIR=`readlink -e ${DIR}/../..`
 
-${PKGDIR}/plugin/generate.sh -i http://petstore.swagger.io/v2/swagger.json -o ${DIR}/MyPetStore -c ${DIR}/config.json
+${PKGDIR}/plugin/generate.sh -i http://127.0.0.1/v2/swagger.json -o ${DIR}/MyPetStore -c ${DIR}/config.json

--- a/test/petstore/runtests.jl
+++ b/test/petstore/runtests.jl
@@ -4,7 +4,7 @@ include("test_UserApi.jl")
 include("test_StoreApi.jl")
 include("test_PetApi.jl")
 
-const server = "http://petstore.swagger.io/v2"
+const server = "http://127.0.0.1/v2"
 TestUserApi.test(server)
 TestStoreApi.test(server)
 TestPetApi.test(server)


### PR DESCRIPTION
The public hosted petstore (http://petstore.swagger.io) is pretty unreliable for tests that do updates. Particularly so for parallel tests.

With this update we will use a local docker based petstore server to run our tests.