### PR TITLE
import hasproperty from Base when appropriate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Swagger"
 uuid = "2d69052b-6a58-5cd9-a030-a48559c324ac"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 </project>

--- a/src/Swagger.jl
+++ b/src/Swagger.jl
@@ -5,9 +5,11 @@ using JSON
 using MbedTLS
 using Dates
 
-import Base: convert, show, summary, getindex, keys, length, getproperty, setproperty!, propertynames
+import Base: convert, show, summary, getindex, keys, length, getproperty, setproperty!, propertynames, iterate
+if isdefined(Base, :hasproperty)
+    import Base: hasproperty
+end
 import JSON: lower
-import Base: iterate
 
 abstract type SwaggerModel end
 abstract type SwaggerApi end


### PR DESCRIPTION
- `hasproperty` should be imported from Base for Julia > v1.1
- also updated maven compiler source and taeger to 1.7 as that seems to be the minimum version supported on osx now