### PR TITLE
allow long polling request to be interrupted

### DIFF
--- a/test/petstore/test_StoreApi.jl
+++ b/test/petstore/test_StoreApi.jl
@@ -42,6 +42,11 @@ function test(uri)
         end
     end
 
+    # a closed channel is equivalent of cancellation of the call, no error should be thrown
+    @test !isopen(response_channel)
+    resp = getOrderById(api, response_channel, 10)
+    @test (200 <= resp.status <= 206)
+
     @info("StoreApi - deleteOrder")
     @test deleteOrder(api, 10) === nothing
 


### PR DESCRIPTION
Allow long polling request to be interrupted by closing the output channel.
There is no ready API/mechanism in Downloads.jl to interrupt a request.
Here we just throw an InterruptedException to the task that invoked Downloads.request.

Note: A better mechanism may be to invoke `remove_handle(multi::Multi, easy::Easy)`, but that should probably be through an interruption mechanism provided by Downloads.jl?