### PR TITLE
fix chunked response interruption handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenApi", "REST"]
 license = "MIT"
 desc = "Swagger (OpenAPI) helper and code generator for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/client.jl
+++ b/src/client.jl
@@ -308,7 +308,7 @@ function do_request(ctx::Ctx, stream::Bool=false; stream_to::Union{Channel,Nothi
                             put!(stream_to, data)
                         end
                     catch ex
-                        if !isa(ex, InvalidStateException)
+                        if !isa(ex, InvalidStateException) && isopen(stream_to)
                             @error("exception reading chunk", exception=(ex,catch_backtrace()))
                             rethrow()
                         end


### PR DESCRIPTION
When the caller closes the response stream in order to interrupt the streaming chunked request, Swagger task may get partial data. It should not throw an error in that case.