### PR TITLE
handle race in chunked response handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenApi", "REST"]
 license = "MIT"
 desc = "Swagger (OpenAPI) helper and code generator for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/petstore/test_StoreApi.jl
+++ b/test/petstore/test_StoreApi.jl
@@ -42,10 +42,11 @@ function test(uri)
         end
     end
 
-    # a closed channel is equivalent of cancellation of the call, no error should be thrown
+    # a closed channel is equivalent of cancellation of the call,
+    # no error should be thrown, but response can be nothing if call was interrupted immediately
     @test !isopen(response_channel)
     resp = getOrderById(api, response_channel, 10)
-    @test (200 <= resp.status <= 206)
+    @test (resp === nothing) || (200 <= resp.status <= 206)
 
     @info("StoreApi - deleteOrder")
     @test deleteOrder(api, 10) === nothing


### PR DESCRIPTION
handle condition where output channel is closed already before the check and wait to detect it starts.