### PR TITLE
generate julia docs from descriptions in spec

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenApi", "REST"]
 license = "MIT"
 desc = "Swagger (OpenAPI) helper and code generator for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/plugin/build.sh
+++ b/plugin/build.sh
@@ -5,7 +5,7 @@ cd ${DIR}/../plugin
 echo "Building Julia plugin..."
 mvn package
 mvn dependency:resolve dependency:build-classpath -Dmdep.outputFile=classpath.tmp
-echo "`cat classpath.tmp`:$DIR/target/julia-swagger-codegen-0.0.5.jar" > classpath
+echo "`cat classpath.tmp`:$DIR/target/julia-swagger-codegen-0.0.6.jar" > classpath
 rm -f ./classpath.tmp
 echo "Build successful"
 echo "---------------------------------------"

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.juliacomputing.swagger.codegen</groupId>
   <artifactId>julia-swagger-codegen</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.5</version>
+  <version>0.0.6</version>
   <name>julia-swagger-codegen</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/plugin/src/main/resources/julia/api.mustache
+++ b/plugin/src/main/resources/julia/api.mustache
@@ -5,14 +5,6 @@ struct {{classname}} <: SwaggerApi
 end
 
 {{#operation}}
-"""
-{{{summary}}}
-{{{notes}}}
-{{#allParams}}
-Param: {{paramName}}::{{dataType}}{{#required}} (required){{/required}}
-{{/allParams}}
-Return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
-"""
 function _swaggerinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#required}}, {{paramName}}{{^isBodyParam}}::{{dataType}}{{/isBodyParam}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
 {{#allParams}}
 {{#hasValidation}}
@@ -60,6 +52,14 @@ function _swaggerinternal_{{operationId}}(_api::{{classname}}{{#allParams}}{{#re
     return _ctx
 end
 
+"""
+{{{summary}}}
+{{{notes}}}
+{{#allParams}}
+Param: {{paramName}}::{{dataType}}{{#required}} (required){{/required}}
+{{/allParams}}
+Return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Nothing{{/returnType}}
+"""
 function {{operationId}}(_api::{{classname}}{{#allParams}}{{#required}}, {{paramName}}{{^isBodyParam}}::{{dataType}}{{/isBodyParam}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}=nothing,{{/required}}{{/allParams}} _mediaType=nothing)
     _ctx = _swaggerinternal_{{operationId}}(_api{{#allParams}}{{#required}}, {{paramName}}{{/required}}{{/allParams}};{{#allParams}}{{^required}} {{paramName}}={{paramName}},{{/required}}{{/allParams}} _mediaType=_mediaType)
     Swagger.exec(_ctx)

--- a/plugin/src/main/resources/julia/model.mustache
+++ b/plugin/src/main/resources/julia/model.mustache
@@ -8,6 +8,19 @@ else
     @warn("Skipping redefinition of {{classname}} to {{dataType}}")
 end
 {{/isAlias}}{{^isAlias}}
+@doc raw"""{{#description}}{{description}}
+{{/description}}
+
+    {{classname}}(;
+{{#allVars}}
+        {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}nothing{{/defaultValue}},
+{{/allVars}}
+    )
+
+{{#allVars}}
+    - {{name}}::{{datatype}}{{#description}} : {{description}}{{/description}}
+{{/allVars}}
+"""
 mutable struct {{classname}} <: SwaggerModel
 {{#allVars}}
     {{name}}::Any # spec type: Union{ Nothing, {{datatype}} } # spec name: {{baseName}}


### PR DESCRIPTION
This updates the code generation templates to also generate julia docstrings for models and also make use of the description strings in the specification files if available. Having doc strings for models is useful while coding for new instances of those in Julia.

Also corrects the position of generated API docstring to be with the exported API method instead of the internal method. And bumps the patch version for tagging.