### PR TITLE
allow timeout to be set via client instance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenApi", "REST"]
 license = "MIT"
 desc = "Swagger (OpenAPI) helper and code generator for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ The client context needs to be passed as the first parameter of all API calls. I
 Client(root::String;
     headers::Dict{String,String}=Dict{String,String}(),
     get_return_type::Function=(default,data)->default,
-    long_polling_timeout::Int=DEFAULT_LONGPOLL_TIMEOUT_SECS)
+    timeout::Int=DEFAULT_TIMEOUT_SECS,
+    long_polling_timeout::Int=DEFAULT_LONGPOLL_TIMEOUT_SECS,
+)
 ```
 
 Where:
@@ -81,6 +83,7 @@ Where:
 - `root`: the root URI where APIs are hosted (should not end with a `/`)
 - `headers`: any additional headers that need to be passed along with all API calls
 - `get_return_type`: optional method that can map a Julia type to a return type other than what is specified in the API specification by looking at the data (this is used only in special cases, for example when models are allowed to be dynamically loaded)
+- `timeout`: optional timeout to apply for server methods (default `Swagger.DEFAULT_TIMEOUT_SECS`)
 - `long_polling_timeout`: optional timeout to apply for long polling methods (default `Swagger.DEFAULT_LONGPOLL_TIMEOUT_SECS`)
 
 In case of any errors an instance of `ApiException` is thrown. It has the following fields:

--- a/test/petstore/runtests.jl
+++ b/test/petstore/runtests.jl
@@ -6,6 +6,7 @@ include("test_PetApi.jl")
 
 const server = "http://127.0.0.1/v2"
 TestUserApi.test_404(server)
+TestUserApi.test_set_methods()
 
 if get(ENV, "STRESS_PETSTORE", "false") == "true"
     TestUserApi.test_parallel(server)

--- a/test/petstore/test_UserApi.jl
+++ b/test/petstore/test_UserApi.jl
@@ -35,6 +35,33 @@ function test_404(uri)
     end    
 end
 
+function test_set_methods()
+    @info("Error handling")
+    client = Swagger.Client("http://_invalid/")
+
+    @test client.timeout[] == Swagger.DEFAULT_TIMEOUT_SECS
+
+    Swagger.with_timeout(client, Swagger.DEFAULT_TIMEOUT_SECS + 10) do client
+        @test client.timeout[] == Swagger.DEFAULT_TIMEOUT_SECS + 10
+    end
+    @test client.timeout[] == Swagger.DEFAULT_TIMEOUT_SECS
+
+    api = UserApi(client)
+    Swagger.with_timeout(api, Swagger.DEFAULT_TIMEOUT_SECS + 10) do api
+        @test api.client.timeout[] == Swagger.DEFAULT_TIMEOUT_SECS + 10
+    end
+    @test client.timeout[] == Swagger.DEFAULT_TIMEOUT_SECS
+
+    Swagger.set_timeout(client, Swagger.DEFAULT_TIMEOUT_SECS + 10)
+    @test client.timeout[] == Swagger.DEFAULT_TIMEOUT_SECS + 10
+
+    @test isempty(client.headers)
+    Swagger.set_user_agent(client, "007")
+    Swagger.set_cookie(client, "crumbly")
+    @test client.headers["User-Agent"] == "007"
+    @test client.headers["Cookie"] == "crumbly"
+end
+
 function test_parallel(uri)
     @info("Parallel usage")
     client = Swagger.Client(uri)


### PR DESCRIPTION
Swagger client instance now holds a request timeout value that can be set via a new `set_timeout` method.
Swagger call context picks up request timeout from the client instance passed to it during instantiation, instead of using the default.

e.g.:

```julia

client = Swagger.Client(url;
            headers=Dict{String,String}(),
            get_return_type=(default,data)->default,
            long_polling_timeout=600,
            timeout=30)

Swagger.set_timeout(client, 60)

api = UserApi(client)
...

Swagger.with_timeout(client, 60) do client
    api = UserApi(client)
end

```