### PR TITLE
codegen generates directly to src folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+*.jl.*.mem
+.vscode
 swagger-codegen-*

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenApi", "REST"]
 license = "MIT"
 desc = "Swagger (OpenAPI) helper and code generator for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _where_
 `SPECFILE` the name of the openapi specification file from which you are generating Julia code
 `GENDIR` the directory where the generated Julia code will be written
 
-Typically, you would generate the files into a `src` directory for a package. The generated code is ready to be used as a Julia package directly (So long as the package name is passed correctly -- see below)
+Typically, you would generate the files into a `src` directory for a package. The generated code is ready to be used as a Julia module directly.
 
 The configuration file (`config.json`) can have the following options:
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -16,10 +16,10 @@ To build the project, run this:
 plugin/build.sh
 ```
 
-A single jar file (julia-swagger-codegen-0.0.2.jar) will be produced in `plugin/target`.  You can now use that with codegen:
+A single jar file (julia-swagger-codegen-0.0.7.jar) will be produced in `plugin/target`.  You can now use that with codegen:
 
 ```
-java -cp /path/to/swagger-codegen-cli.jar:/path/to/julia-swagger-codegen-0.0.2.jar io.swagger.codegen.Codegen -l julia -i /path/to/swagger.yaml -o ./test -c config.json
+java -cp /path/to/swagger-codegen-cli.jar:/path/to/julia-swagger-codegen-0.0.7.jar io.swagger.codegen.Codegen -l julia -i /path/to/swagger.yaml -o ./test -c config.json
 ```
 
 The configuration file (`config.json`) can have the following options:

--- a/plugin/build.sh
+++ b/plugin/build.sh
@@ -5,7 +5,7 @@ cd ${DIR}/../plugin
 echo "Building Julia plugin..."
 mvn package
 mvn dependency:resolve dependency:build-classpath -Dmdep.outputFile=classpath.tmp
-echo "`cat classpath.tmp`:$DIR/target/julia-swagger-codegen-0.0.6.jar" > classpath
+echo "`cat classpath.tmp`:$DIR/target/julia-swagger-codegen-0.0.7.jar" > classpath
 rm -f ./classpath.tmp
 echo "Build successful"
 echo "---------------------------------------"

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.juliacomputing.swagger.codegen</groupId>
   <artifactId>julia-swagger-codegen</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.6</version>
+  <version>0.0.7</version>
   <name>julia-swagger-codegen</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/plugin/src/main/java/com/juliacomputing/swagger/codegen/JuliaGenerator.java
+++ b/plugin/src/main/java/com/juliacomputing/swagger/codegen/JuliaGenerator.java
@@ -13,8 +13,11 @@ public class JuliaGenerator extends DefaultCodegen implements CodegenConfig {
 
     protected String packageName;
 
-    // source folder where to write the files
-    protected String sourceFolder = "src";
+    // Source folder where to write the files
+    // Disabled for now, but this can be appended to outputFolder along with
+    // other path elements like packageName to get the final outputFolder in
+    // methods like modelFileFolder and apiFileFolder
+    // protected String sourceFolder = "src";
     protected String apiVersion = "1.0.0";
 
     /**
@@ -135,8 +138,8 @@ public class JuliaGenerator extends DefaultCodegen implements CodegenConfig {
 
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
 
-        supportingFiles.add(new SupportingFile("client.mustache", "src", packageName + ".jl"));
-        supportingFiles.add(new SupportingFile("modelincludes.mustache", "src", "modelincludes.jl"));
+        supportingFiles.add(new SupportingFile("client.mustache", packageName + ".jl"));
+        supportingFiles.add(new SupportingFile("modelincludes.mustache", "modelincludes.jl"));
     }
 
     /**
@@ -158,7 +161,7 @@ public class JuliaGenerator extends DefaultCodegen implements CodegenConfig {
      * Location to write model files.
      */
     public String modelFileFolder() {
-        return outputFolder + "/" + sourceFolder;
+        return outputFolder;
     }
 
     /**
@@ -166,7 +169,7 @@ public class JuliaGenerator extends DefaultCodegen implements CodegenConfig {
      */
     @Override
     public String apiFileFolder() {
-        return outputFolder + "/" + sourceFolder;
+        return outputFolder;
     }
 
     @Override

--- a/test/petstore/runtests.jl
+++ b/test/petstore/runtests.jl
@@ -1,4 +1,4 @@
-include(joinpath(dirname(@__FILE__), "MyPetStore", "src", "MyPetStore.jl"))
+include(joinpath(dirname(@__FILE__), "MyPetStore", "MyPetStore.jl"))
 
 include("test_UserApi.jl")
 include("test_StoreApi.jl")


### PR DESCRIPTION
Earlier code generator used to create a sub folder named src in the output folder specified where it used to generate all sources. But that seems confusing and unnecessary. Most users use the generated code as a sub module in their repo. This changes the generator to output directly to whatever output folder is provided.