### PR TITLE
hooks to allow changing request before submission

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ URIs = "1.3"
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "URIs"]

--- a/test/petstore/runtests.jl
+++ b/test/petstore/runtests.jl
@@ -6,6 +6,7 @@ include("test_PetApi.jl")
 
 const server = "http://127.0.0.1/v2"
 TestUserApi.test_404(server)
+TestUserApi.test_userhook(server)
 TestUserApi.test_set_methods()
 
 if get(ENV, "STRESS_PETSTORE", "false") == "true"


### PR DESCRIPTION
This allows a `pre_request_hook` method to be specified while creating a Swagger client instance that can change the request before it is submitted to the server. Useful to make adhoc changes to requests.

The hook is invoked in two stages:
- `pre_request_hook(ctx::Swagger.Ctx) -> ctx`: invoked with the raw request context before the request is prepared, returns the context back after modification
- `pre_request_hook(resource_path::AbstractString, body::Any, headers::Dict{String,String}) -> (resource_path, body, headers))`: invoked with a prepared request, consisting of the resource path, request body and request headers, returns the inputs back after modifications as a tuple

The hook method can make any changes to the supplied parameters and return them back. The returned values will be used subsequently.