### PR TITLE
add utility method to check longpoll timeout

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["Swagger", "OpenApi", "REST"]
 license = "MIT"
 desc = "Swagger (OpenAPI) helper and code generator for Julia"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,27 @@
 using Swagger
 using Test
 
-# set the current julia executable to be used henceforth
-("JULIA" in keys(ENV)) || (ENV["JULIA"] = joinpath(Sys.BINDIR, "julia"))
-
 const gencmd = joinpath(dirname(@__FILE__()), "petstore", "generate.sh")
-@info("Generating petstore", gencmd)
-run(`$gencmd`)
 
-if ENV["RUNNER_OS"] == "Linux"
-    @info("Running petstore tests")
-    include("petstore/runtests.jl")
-else
-    @info("Skipping petstore tests in OSX (can not run petstore docker on travis OSX)")
+include("utilstests.jl")
+
+@testset "Swagger" begin
+    @testset "Utils" begin
+        test_longpoll_exception_check()
+    end
+    @testset "Code generation" begin
+        # set the current julia executable to be used henceforth
+        ("JULIA" in keys(ENV)) || (ENV["JULIA"] = joinpath(Sys.BINDIR, "julia"))
+
+        @info("Generating petstore", gencmd)
+        run(`$gencmd`)
+    end
+    @testset "Petstore" begin
+        if get(ENV, "RUNNER_OS", "") == "Linux"
+            @info("Running petstore tests")
+            include("petstore/runtests.jl")
+        else
+            @info("Skipping petstore tests in non Linux environment (can not run petstore docker on OSX or Windows)")
+        end
+    end
 end

--- a/test/utilstests.jl
+++ b/test/utilstests.jl
@@ -1,0 +1,30 @@
+using Swagger, Test
+
+function as_taskfailedexception(ex)
+    try
+        task = @async throw(ex)
+        wait(task)
+    catch ex
+        return ex
+    end
+end
+
+function test_longpoll_exception_check()
+    resp = Swagger.Downloads.Response("http", "http://localhost", 200, "no error", [])
+    reqerr1 = Swagger.Downloads.RequestError("http://localhost", 500, "not timeout error", resp)
+    reqerr2 = Swagger.Downloads.RequestError("http://localhost", 200, "Operation timed out after 300 milliseconds with 0 bytes received", resp) # timeout error
+
+    @test Swagger.is_longpoll_timeout("not an exception") == false
+
+    swaggerex1 = Swagger.ApiException(reqerr1)
+    @test Swagger.is_longpoll_timeout(swaggerex1) == false
+    @test Swagger.is_longpoll_timeout(as_taskfailedexception(swaggerex1)) == false
+
+    swaggerex2 = Swagger.ApiException(reqerr2)
+    @test Swagger.is_longpoll_timeout(swaggerex2)
+    @test Swagger.is_longpoll_timeout(as_taskfailedexception(swaggerex2))
+
+    @test Swagger.is_longpoll_timeout(CompositeException([swaggerex1, swaggerex2]))
+    @test Swagger.is_longpoll_timeout(CompositeException([swaggerex1, as_taskfailedexception(swaggerex2)]))
+    @test Swagger.is_longpoll_timeout(CompositeException([swaggerex1, as_taskfailedexception(swaggerex1)])) == false
+end


### PR DESCRIPTION
Adds a utility method `is_longpoll_timeout` that can be used to check if the exception thrown is due to long polling timing out at Curl level.
If the exception is a nested exception of type CompositeException or TaskFailedException, then it navigates through the nested exception values to examine the leaves.